### PR TITLE
fix: typo in `index.ts` file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ app.use(
 		origin: '*', // Allow any origin for development; restrict this in production
 		allowMethods: ['POST', 'GET', 'OPTIONS'],
 		allowHeaders: ['Content-Type'],
-		exposeHeaders: ['X-Session-Id'],x
+		exposeHeaders: ['X-Session-Id'],
 		maxAge: 86400, // 24 hours
 	}),
 );


### PR DESCRIPTION
A typographical error in the file was stopping the agent from running, removing it fixes the issue.